### PR TITLE
Depend on the stable version of Drupal Extension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "drupal/drupal-extension": "dev-master",
+        "drupal/drupal-extension": "~4.1",
         "friends-of-behat/service-container-extension": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Drupal Extension 4.1 has been released some time ago. This includes the new dependency of the authentication manager that we needed. We can revert back to the stable version.