### PR TITLE
Quote YAML strings

### DIFF
--- a/behat.services.yml
+++ b/behat.services.yml
@@ -5,5 +5,5 @@ services:
       - "@mink"
       - "@drupal.user_manager"
       - "@drupal.drupal"
-      - %mink.parameters%
-      - %drupal.parameters%
+      - "%mink.parameters%"
+      - "%drupal.parameters%"


### PR DESCRIPTION
See https://github.com/Behat/Behat/issues/1216.

Without this I get the following error:
```
  The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 8 (near "- %mink.parameters%").  
```