### PR TITLE
Should work also with HTTPS base URL

### DIFF
--- a/src/AuthenticationManager.php
+++ b/src/AuthenticationManager.php
@@ -96,7 +96,7 @@ class AuthenticationManager extends DrupalAuthenticationManager
                 // base URL manually.
                 // @todo Remove this workaround once this is fixed in core.
                 // @see https://www.drupal.org/project/drupal/issues/2548095
-                'base_url' => $GLOBALS['base_url'],
+                'base_url' => $this->getMinkParameter('base_url'),
             ]
         )->toString();
     }


### PR DESCRIPTION
If `default.extensions.Drupal\MinkExtension.base_url` is set to a URL using HTTPS, `$GLOBALS['base_url']` still returns `http` as scheme (don't know why). On the following step, an HTTPS request fails to get the cookie as it has been set previously with HTTP. Use the `behat.yml` base URL to compute the reset link